### PR TITLE
Changes to get GWork to compile on Windows/VS2015

### DIFF
--- a/source/gwork/include/Gwork/Controls/Label.h
+++ b/source/gwork/include/Gwork/Controls/Label.h
@@ -41,7 +41,7 @@ namespace Gwk
 
             virtual void SizeToContents();
 
-            virtual void SetAlignment(enum Position area);
+            virtual void SetAlignment(Position area);
             virtual Position GetAlignment();
 
             virtual void SetFont(Gwk::String strFacename, int iSize, bool bBold);

--- a/source/gwork/source/Controls/Canvas.cpp
+++ b/source/gwork/source/Controls/Canvas.cpp
@@ -16,6 +16,8 @@
 #include <Gwork/Anim.h>
 #endif
 
+#include <cctype>
+
 using namespace Gwk::Controls;
 
 
@@ -218,7 +220,7 @@ bool Canvas::InputCharacter(Gwk::UnicodeChar chr)
         return false;
 
     // Check if character is printable, i.e. don't want hidden codes, like backspace.
-    if (!isprint(chr))
+    if (!std::isprint(chr))
         return false;
 
     // Handle Accelerators

--- a/source/gwork/source/Controls/Canvas.cpp
+++ b/source/gwork/source/Controls/Canvas.cpp
@@ -5,7 +5,6 @@
  *  See license in Gwork.h
  */
 
-
 #include <Gwork/Gwork.h>
 #include <Gwork/Controls/Canvas.h>
 #include <Gwork/Skin.h>
@@ -219,7 +218,7 @@ bool Canvas::InputCharacter(Gwk::UnicodeChar chr)
         return false;
 
     // Check if character is printable, i.e. don't want hidden codes, like backspace.
-    if (!std::isprint(chr))
+    if (!isprint(chr))
         return false;
 
     // Handle Accelerators

--- a/source/gwork/source/Utility.cpp
+++ b/source/gwork/source/Utility.cpp
@@ -15,6 +15,11 @@
 #include <locale>       // Narrow/widen
 #include <codecvt>      // Narrow/widen - C++11
 
+#ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 #include "DebugBreak.h"
 
 namespace Gwk {


### PR DESCRIPTION
These are the changes I made to get GWork compiling using Visual Studio 2015.

I had to remove the enum because I was getting this error:

> C:\code\GWork\source\gwork\include\Gwork/Controls/Label.h(44): error C3431: 'Position': a scoped enumeration cannot be redeclared as an unscoped enumeration

I'm not sure what it means, but I don't think it's required?

isprint doesn't seem to be in the std namespace in VS2015. Tested on Linux gcc 6.1.1 and OSX clang 7.3.0 and it still compiles with this change.

Had to add the Windows header to get OutputDebugStringA, MessageBoxA, etc working in Utility.cpp
