### PR TITLE
For Allegro5 map numpad enter key to Gwk::Key::Return

### DIFF
--- a/source/platform/include/Gwork/Input/Allegro5.h
+++ b/source/platform/include/Gwork/Input/Allegro5.h
@@ -40,6 +40,7 @@ namespace Gwk
                     return Gwk::Key::Backspace;
 
                 case ALLEGRO_KEY_ENTER:
+                case ALLEGRO_KEY_PAD_ENTER:
                     return Gwk::Key::Return;
 
                 case ALLEGRO_KEY_ESCAPE:


### PR DESCRIPTION
I was originally going to map the other keys too like arrows and page up/etc, but the only other numpad key that Allegro allows is delete, so I only did enter for now.