### PR TITLE
Add text length limit on TextBox control

### DIFF
--- a/source/gwork/include/Gwork/Controls/TextBox.h
+++ b/source/gwork/include/Gwork/Controls/TextBox.h
@@ -63,6 +63,9 @@ namespace Gwk
             virtual void SetCursorPos(int i);
             virtual void SetCursorEnd(int i);
 
+            void SetMaxTextLength(int maxLength) { m_maxTextLength = maxLength; }
+            const int& GetMaxTextLength() const { return m_maxTextLength; }
+
             void OnMouseClickLeft(int x, int y, bool bDown) override;
             void OnMouseMoved(int x, int y, int deltaX, int deltaY) override;
 
@@ -101,6 +104,8 @@ namespace Gwk
             int m_cursorPos;
             int m_cursorEnd;
             int m_cursorLine;
+
+            int m_maxTextLength;
 
             Gwk::Rect m_rectSelectionBounds;
             Gwk::Rect m_rectCaretBounds;

--- a/source/gwork/include/Gwork/Controls/TextBox.h
+++ b/source/gwork/include/Gwork/Controls/TextBox.h
@@ -64,7 +64,7 @@ namespace Gwk
             virtual void SetCursorEnd(int i);
 
             void SetMaxTextLength(int maxLength) { m_maxTextLength = maxLength; }
-            const int& GetMaxTextLength() const { return m_maxTextLength; }
+            int GetMaxTextLength() const { return m_maxTextLength; }
 
             void OnMouseClickLeft(int x, int y, bool bDown) override;
             void OnMouseMoved(int x, int y, int deltaX, int deltaY) override;
@@ -89,6 +89,8 @@ namespace Gwk
 
             Event::Caller onTextChanged;
             Event::Caller onReturnPressed;
+
+            static constexpr int NO_MAX_LENGTH = -1;
 
         protected:
 

--- a/source/gwork/source/Controls/TextBox.cpp
+++ b/source/gwork/source/Controls/TextBox.cpp
@@ -46,7 +46,7 @@ GWK_CONTROL_CONSTRUCTOR(TextBox)
     m_cursorLine = 0;
     m_bEditable = true;
     m_bSelectAll = false;
-    m_maxTextLength = -1;
+    m_maxTextLength = NO_MAX_LENGTH;
     SetTextColor(Gwk::Color(50, 50, 50, 255));         // TODO: From Skin
     SetTabable(true);
     AddAccelerator("Ctrl + C", &TextBox::OnCopy);
@@ -80,7 +80,7 @@ void TextBox::InsertText(const Gwk::String& strInsert)
         return;
 
     int insertSize = static_cast<int>(strInsert.size());
-    if (m_maxTextLength > -1 && TextLength() + insertSize > m_maxTextLength)
+    if (m_maxTextLength > NO_MAX_LENGTH && TextLength() + insertSize > m_maxTextLength)
     {
         insertSize = m_maxTextLength - TextLength();
         

--- a/source/gwork/source/Controls/TextBox.cpp
+++ b/source/gwork/source/Controls/TextBox.cpp
@@ -46,6 +46,7 @@ GWK_CONTROL_CONSTRUCTOR(TextBox)
     m_cursorLine = 0;
     m_bEditable = true;
     m_bSelectAll = false;
+    m_maxTextLength = -1;
     SetTextColor(Gwk::Color(50, 50, 50, 255));         // TODO: From Skin
     SetTabable(true);
     AddAccelerator("Ctrl + C", &TextBox::OnCopy);
@@ -69,7 +70,6 @@ void TextBox::InsertText(const Gwk::String& strInsert)
     if (!m_bEditable)
         return;
 
-    // TODO: Make sure fits (implement maxlength)
     if (HasSelection())
         EraseSelection();
 
@@ -79,10 +79,19 @@ void TextBox::InsertText(const Gwk::String& strInsert)
     if (!IsTextAllowed(strInsert, m_cursorPos))
         return;
 
+    int insertSize = static_cast<int>(strInsert.size());
+    if (m_maxTextLength > -1 && TextLength() + insertSize > m_maxTextLength)
+    {
+        insertSize = m_maxTextLength - TextLength();
+        
+        if (insertSize <= 0)
+            return;
+    }
+
     String str = GetText();
-    str.insert(m_cursorPos, strInsert);
+    str.insert(m_cursorPos, strInsert, 0, insertSize);
     SetText(str);
-    m_cursorPos += static_cast<int>(strInsert.size());
+    m_cursorPos += insertSize;
     m_cursorEnd = m_cursorPos;
     m_cursorLine = 0;
     RefreshCursorBounds();

--- a/source/test/source/api/TextBox.cpp
+++ b/source/test/source/api/TextBox.cpp
@@ -88,6 +88,13 @@ public:
             label->SetPos(220, 195);
             label->SetSize(200, 45);
         }
+        {
+            Gwk::Controls::TextBoxMultiline* label = new Gwk::Controls::TextBoxMultiline(this);
+            label->SetMaxTextLength(20);
+            label->SetText("Max Length 20 -- Set text longer than max length");
+            label->SetPos(220, 245);
+            label->SetSize(200, 45);
+        }
     }
 
     void OnEdit(Gwk::Controls::Base* control)

--- a/source/test/source/api/TextBox.cpp
+++ b/source/test/source/api/TextBox.cpp
@@ -41,17 +41,30 @@ public:
             label->SetPos(10, 10+25*3);
         }
         {
+            Gwk::Controls::TextBox* label = new Gwk::Controls::TextBox(this);
+            label->SetText("Max Length 15");
+            label->SetMaxTextLength(15);
+            label->SetPos(10, 10+25*4);
+        }
+        {
             Gwk::Controls::TextBoxNumeric* label = new Gwk::Controls::TextBoxNumeric(this);
             label->SetText("2004");
             label->SetTextColor(Gwk::Color(255, 0, 255, 255));
-            label->SetPos(10, 10+25*4);
+            label->SetPos(10, 10+25*5);
+        }
+        {
+            Gwk::Controls::TextBoxNumeric* label = new Gwk::Controls::TextBoxNumeric(this);
+            label->SetText("3.14159265");
+            label->SetTextColor(Gwk::Color(255, 0, 255, 255));
+            label->SetPos(10, 10+25*6);
+            label->SetMaxTextLength(10);
         }
         {
             m_font.facename = "Impact";
             m_font.size = 50;
             Gwk::Controls::TextBox* label = new Gwk::Controls::TextBox(this);
             label->SetText("Different Font");
-            label->SetPos(10, 10+25*5);
+            label->SetPos(10, 10+25*7);
             label->SetFont(&m_font);
             label->SetSize(200, 55);
         }
@@ -67,6 +80,13 @@ public:
             "vehicula, nunc lacus egestas leo, volutpat egestas augue.");
             label->SetPos(220, 10);
             label->SetSize(200, 180);
+        }
+        {
+            Gwk::Controls::TextBoxMultiline* label = new Gwk::Controls::TextBoxMultiline(this);
+            label->SetText("Max Length 20");
+            label->SetMaxTextLength(20);
+            label->SetPos(220, 195);
+            label->SetSize(200, 45);
         }
     }
 

--- a/source/test/source/api/TextBox.cpp
+++ b/source/test/source/api/TextBox.cpp
@@ -85,14 +85,8 @@ public:
             Gwk::Controls::TextBoxMultiline* label = new Gwk::Controls::TextBoxMultiline(this);
             label->SetText("Max Length 20");
             label->SetMaxTextLength(20);
-            label->SetPos(220, 195);
-            label->SetSize(200, 45);
-        }
-        {
-            Gwk::Controls::TextBoxMultiline* label = new Gwk::Controls::TextBoxMultiline(this);
-            label->SetMaxTextLength(20);
             label->SetText("Max Length 20 -- Set text longer than max length");
-            label->SetPos(220, 245);
+            label->SetPos(220, 195);
             label->SetSize(200, 45);
         }
     }


### PR DESCRIPTION
As per the discussion, went with an approach that once the limit is reached no more text can be entered. This seems to be the standard behaviour used by other applications and makes sense.

Can adjust naming/stuff if required.