### PR TITLE
Made some fixes to NumericUpDown control that make it more usable.

### DIFF
--- a/source/gwork/include/Gwork/Controls/NumericUpDown.h
+++ b/source/gwork/include/Gwork/Controls/NumericUpDown.h
@@ -56,6 +56,7 @@ namespace Gwk
             virtual void SetMin(int i);
             virtual void SetMax(int i);
             virtual void SetIntValue(int i);
+            virtual int GetIntValue();
 
             Event::Caller onChanged;
 
@@ -63,7 +64,6 @@ namespace Gwk
 
             void OnEnter() override;
             virtual void OnChange();
-            void OnTextChanged() override;
 
             virtual void OnButtonUp(Base* control);
             virtual void OnButtonDown(Base* control);
@@ -84,14 +84,11 @@ namespace Gwk
                 return true;
             }
 
-            virtual void SyncTextFromNumber();
-            virtual void SyncNumberFromText();
+            virtual int GetIntValueUnclamped();
 
-
-            int m_number;
             int m_max;
             int m_min;
-
+            int m_lastNumber;
         };
 
 

--- a/source/gwork/source/Controls/NumericUpDown.cpp
+++ b/source/gwork/source/Controls/NumericUpDown.cpp
@@ -34,30 +34,28 @@ GWK_CONTROL_CONSTRUCTOR(NumericUpDown)
     buttonUp->SetPadding(Padding(0, 1, 1, 0));
     m_max = 100;
     m_min = 0;
-    m_number = 0;
+    m_lastNumber = 0;
     SetText("0");
 }
 
 void NumericUpDown::OnButtonUp(Base* /*control*/)
 {
-    SyncNumberFromText();
-    SetIntValue(m_number+1);
+    SetIntValue(GetIntValueUnclamped() + 1);
 }
 
 void NumericUpDown::OnButtonDown(Base* /*control*/)
 {
-    SyncNumberFromText();
-    SetIntValue(m_number-1);
+    SetIntValue(GetIntValueUnclamped() - 1);
 }
 
-void NumericUpDown::SyncTextFromNumber()
+int NumericUpDown::GetIntValueUnclamped()
 {
-    SetText(Utility::ToString(m_number));
+    return static_cast<int>(std::lround(GetFloatFromText()));
 }
 
-void NumericUpDown::SyncNumberFromText()
+int NumericUpDown::GetIntValue()
 {
-    SetIntValue(static_cast<int>(std::lround(GetFloatFromText())));
+    return Clamp(GetIntValueUnclamped(), m_min, m_max);
 }
 
 void NumericUpDown::SetMin(int i)
@@ -74,17 +72,13 @@ void NumericUpDown::SetIntValue(int i)
 {
     i = Clamp(i, m_min, m_max);
 
-    if (m_number == i)
-        return;
+    SetText(Utility::ToString(i));
 
-    m_number = i;
-    // Don't update the text if we're typing in it..
-    // Undone - any reason why not?
-    // if ( !IsFocussed() )
+    if (m_lastNumber != i)
     {
-        SyncTextFromNumber();
+        m_lastNumber = i;
+        OnChange();
     }
-    OnChange();
 }
 
 void NumericUpDown::OnChange()
@@ -92,15 +86,8 @@ void NumericUpDown::OnChange()
     onChanged.Call(this);
 }
 
-void NumericUpDown::OnTextChanged()
-{
-    ParentClass::OnTextChanged();
-    SyncNumberFromText();
-}
-
 void NumericUpDown::OnEnter()
 {
-    SyncNumberFromText();
-    SyncTextFromNumber();
+    SetIntValue(GetIntValueUnclamped());
     ParentClass::OnEnter();
 }

--- a/source/test/source/api/Numeric.cpp
+++ b/source/test/source/api/Numeric.cpp
@@ -21,12 +21,13 @@ public:
         ctrl->SetIntValue(50);
         ctrl->SetMax(1000);
         ctrl->SetMin(-1000);
-        //	ctrl->onPress.Add( this, &ThisClass::onButtonA );
+        ctrl->onChanged.Add(this, &ThisClass::onChanged);
     }
 
-    void onButtonA(Controls::Base* control)
+    void onChanged(Controls::Base* control)
     {
-        //	OutputToLog( "Button Pressed (using 'OnPress' event)" );
+        Gwk::Controls::NumericUpDown* numeric = (Gwk::Controls::NumericUpDown*)control;
+        OutputToLog(Utility::Format("Numeric Changed: %i", numeric->GetIntValue()));
     }
 
 };


### PR DESCRIPTION
The main fix was to get rid of the `OnTextChanged` handling, since this made the control weird to type in as it would change the value to something else as you were typing.

The other fix was to always set the text in `SetIntValue`, because otherwise when pressing enter in the box with an out of range value, the text would remain as an out of range value. This was caused by comparing the value against the clamped value and exiting early.

I have also now added a public `GetIntValue` method which returns the clamped current value, so user applications can make use of this.

I also got rid of `m_number` and the `Sync*` methods which I think makes the code a little bit simpler to understand.