### PR TITLE
Set the proper text color for multi-line labels.

### DIFF
--- a/source/gwork/include/Gwork/Controls/LabelClickable.h
+++ b/source/gwork/include/Gwork/Controls/LabelClickable.h
@@ -23,7 +23,7 @@ namespace Gwk
             GWK_CONTROL(LabelClickable, Button);
 
             void Render(Skin::Base* skin) override;
-
+            void UpdateColors() override;
         };
 
 

--- a/source/gwork/source/Controls/LabelClickable.cpp
+++ b/source/gwork/source/Controls/LabelClickable.cpp
@@ -24,3 +24,18 @@ void LabelClickable::Render(Skin::Base* /*skin*/)
 {
     // skin->DrawButton( this, IsDepressed(), IsToggle() && GetToggleState() );
 }
+
+
+void LabelClickable::UpdateColors()
+{
+    if (IsDisabled())
+        return SetTextColor(GetSkin()->Colors.Button.Disabled);
+
+    if (IsDepressed() || GetToggleState())
+        return SetTextColor(GetSkin()->Colors.Label.Bright);
+
+    if (IsHovered())
+        return SetTextColor(GetSkin()->Colors.Button.Hover);
+
+    SetTextColor(GetSkin()->Colors.Button.Normal);
+}

--- a/source/gwork/source/Controls/Text.cpp
+++ b/source/gwork/source/Controls/Text.cpp
@@ -332,6 +332,7 @@ void Text::RefreshSizeWrap()
         {
             Text* t = new Text(this);
             t->SetFont(GetFont());
+            t->SetTextColor(TextColor());
             if (bWrapped)
             {
                 t->SetString(strLine.substr(0, strLine.length()-(*it).length()));

--- a/source/gwork/source/Controls/TextBox.cpp
+++ b/source/gwork/source/Controls/TextBox.cpp
@@ -143,7 +143,7 @@ void TextBox::Render(Skin::Base* skin)
 void TextBox::RefreshCursorBounds()
 {
     m_fNextCaretColorChange = Gwk::Platform::GetTimeInSeconds()+1.5f;
-    m_caretColor = Gwk::Color(30, 30, 30, 255);
+    m_caretColor = GetSkin()->Colors.Label.Bright;
     MakeCaretVisible();
     Gwk::Rect pA = GetCharacterPosition(m_cursorPos);
     Gwk::Rect pB = GetCharacterPosition(m_cursorEnd);

--- a/source/platform/renderers/SDL2/SDL2.cpp
+++ b/source/platform/renderers/SDL2/SDL2.cpp
@@ -16,13 +16,11 @@ SDL2::SDL2(SDL_Window *window)
     :   m_window(window)
     ,   m_renderer(nullptr)
 {
-    m_renderer = SDL_CreateRenderer(m_window, -1,
-                                    SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+  m_renderer = SDL_GetRenderer( m_window );
 }
 
 SDL2::~SDL2()
 {
-    SDL_DestroyRenderer(m_renderer);
 }
 
 void SDL2::SetDrawColor(Gwk::Color color)

--- a/source/samples/SDL2/SDL2Sample.cpp
+++ b/source/samples/SDL2/SDL2Sample.cpp
@@ -31,6 +31,7 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 
     // Create a Gwork Allegro Renderer
+    SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
     Gwk::Renderer::SDL2 *renderer = new Gwk::Renderer::SDL2(window);
 
     // Create a Gwork skin

--- a/toolchain-mingw32.cmake
+++ b/toolchain-mingw32.cmake
@@ -1,0 +1,19 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+# which compilers to use for C and C++
+SET(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+SET(CMAKE_CXX_COMPILER x86_64-w64-mingw32-c++)
+SET(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+
+# here is the target environment located
+SET(CMAKE_FIND_ROOT_PATH  /opt/local/x86_64-w64-mingw32 /Users/sabetts/data-drive/work/mingw/SDL2-2.0.6/x86_64-w64-mingw32 /Users/sabetts/data-drive/work/mingw/SDL2_image-2.0.1/x86_64-w64-mingw32 /Users/sabetts/data-drive/work/mingw/SDL2_mixer-2.0.1/x86_64-w64-mingw32 /Users/sabetts/data-drive/work/mingw/SDL2_ttf-2.0.14/x86_64-w64-mingw32 /Users/sabetts/data-drive/work/mingw/iconv_x86_64 )
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search 
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+include_directories(/Users/sabetts/data-drive/work/mingw/iconv_x86_64/include)


### PR DESCRIPTION
If you override the default color of a label and turn wrapping on, the text does not inherit that color. This fixes that bug.