### PR TITLE
Set the proper text color for multi-line labels.

### DIFF
--- a/source/gwork/source/Controls/Text.cpp
+++ b/source/gwork/source/Controls/Text.cpp
@@ -332,6 +332,7 @@ void Text::RefreshSizeWrap()
         {
             Text* t = new Text(this);
             t->SetFont(GetFont());
+            t->SetTextColor(TextColor());
             if (bWrapped)
             {
                 t->SetString(strLine.substr(0, strLine.length()-(*it).length()));


### PR DESCRIPTION
without this fix, labels with multiple lines (from turning on wrapping, for instance) do not inherit the label's color.