### PR TITLE
Update DirectX 11 Renderer

### DIFF
--- a/source/platform/include/Gwork/Renderers/DirectX11.h
+++ b/source/platform/include/Gwork/Renderers/DirectX11.h
@@ -16,22 +16,26 @@ namespace Gwk
 {
     namespace Renderer
     {
-        const wchar_t BeginCharacter = L' ';    // First Character of Wide Character Table
-        const wchar_t LastCharacter = 0x2FFF;   // Last Character of Wide Character Table
-        const wchar_t NewLineCharacter = L'\n'; // New Line Character
+        static const wchar_t BeginCharacter = L' ';    // First Character of Wide Character Table
+        static const wchar_t LastCharacter = 0x2FFF;   // Last Character of Wide Character Table
+        static const wchar_t NewLineCharacter = L'\n'; // New Line Character
 
         //! Default resource loader for DirectX 11.
+        class FontData;
         class DirectX11ResourceLoader : public ResourceLoader
         {
-            ResourcePaths&      m_paths;
-            ID3D11Device*       m_pDevice;
-            Gwk::Font::List     m_FontList;
+            ResourcePaths&          m_paths;
+            ID3D11Device*           m_pDevice;
+            Gwk::Font::List         m_FontList;
+            std::list<FontData*>    m_FontDataList;
 
         public:
             DirectX11ResourceLoader(ResourcePaths& paths, ID3D11Device* pDevice)
                 :   m_paths(paths)
                 ,   m_pDevice(pDevice)
             {}
+
+            ~DirectX11ResourceLoader();
 
             Font::Status LoadFont(Font& font) override;
             void FreeFont(Font& font) override;

--- a/source/platform/include/Gwork/Renderers/DirectX11.h
+++ b/source/platform/include/Gwork/Renderers/DirectX11.h
@@ -16,6 +16,10 @@ namespace Gwk
 {
     namespace Renderer
     {
+        const wchar_t BeginCharacter = L' ';    // First Character of Wide Character Table
+        const wchar_t LastCharacter = 0x2FFF;   // Last Character of Wide Character Table
+        const wchar_t NewLineCharacter = L'\n'; // New Line Character
+
         //! Default resource loader for DirectX 11.
         class DirectX11ResourceLoader : public ResourceLoader
         {
@@ -80,6 +84,7 @@ namespace Gwk
             //virtual void FillPresentParameters(Gwk::WindowProvider* pWindow, DXGI_SWAP_CHAIN_DESC & Params);
 
             FLOAT                   width, height;
+            FLOAT                   scalex, scaley;
             DWORD                   m_Color;
             bool                    m_Valid;
 

--- a/source/platform/include/Gwork/Renderers/DirectX11.h
+++ b/source/platform/include/Gwork/Renderers/DirectX11.h
@@ -36,7 +36,7 @@ namespace Gwk
             void FreeTexture(Texture& texture) override;
         };
 
-#define GwkDxSafeRelease(var) if(var) {var->Release(); var = NULL;}
+#define GwkDxSafeRelease(var) if(var != nullptr) {var->Release(); var = nullptr;}
 
         //
         //! Renderer for [DirectX11](https://en.wikipedia.org/wiki/DirectX#DirectX_11).
@@ -45,7 +45,7 @@ namespace Gwk
         {
         public:
 
-            DirectX11(ResourceLoader& loader, ID3D11Device* pDevice = NULL);
+            DirectX11(ResourceLoader& loader, ID3D11Device* pDevice = nullptr);
             virtual ~DirectX11();
 
             virtual void Init();
@@ -114,8 +114,6 @@ namespace Gwk
 
             void Flush();
             void Present();
-            void AddVert(int x, int y);
-            void AddVert(int x, int y, float u, float v);
 
             struct VertexFormat
             {
@@ -151,6 +149,7 @@ namespace Gwk
                     if (open)
                         End();
                     GwkDxSafeRelease(m_vbuffer);
+                    GwkDxSafeRelease(m_pContext);
                 }
 
                 inline DWORD GetMaxVertices() const { return maxVertices; }
@@ -172,7 +171,7 @@ namespace Gwk
 
                         D3D11_BUFFER_DESC bufdesc = CD3D11_BUFFER_DESC(maxVertices * sizeof(T), D3D11_BIND_VERTEX_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
 
-                        if (FAILED(hr = pDevice->CreateBuffer(&bufdesc, NULL, &m_vbuffer)))
+                        if (FAILED(hr = pDevice->CreateBuffer(&bufdesc, nullptr, &m_vbuffer)))
                             return hr;
 
                         bufferResize = false;
@@ -232,6 +231,7 @@ namespace Gwk
                         maxVertices = numVertices;
                     }
 
+                    GwkDxSafeRelease(m_pContext);
                     return S_OK;
                 }
 

--- a/source/platform/renderers/DirectX11/DirectX11.cpp
+++ b/source/platform/renderers/DirectX11/DirectX11.cpp
@@ -122,7 +122,7 @@ static HRESULT CompileShaderFromMemory(const char* szdata, SIZE_T len, LPCSTR sz
 }
 #pragma endregion
 
-const wchar_t BeginCharacter = 0x32;
+const wchar_t BeginCharacter = L' ';
 const wchar_t LastCharacter = 0x7FF;
 const wchar_t NewLineCharacter = L'\n';
 
@@ -794,7 +794,8 @@ void DirectX11::RenderText(Gwk::Font* pFont, Gwk::Point pos, const Gwk::String &
         if (wide_char == NewLineCharacter)
         {
             loc.x = fStartX;
-            loc.y += (data->m_TexCoords[c].w - data->m_TexCoords[c].y) * data->m_TexHeight;
+            loc.y += (data->m_TexCoords[BeginCharacter].w - data->m_TexCoords[BeginCharacter].y) * data->m_TexHeight;
+            continue;
         }
         else if (wide_char < BeginCharacter || wide_char > LastCharacter)
             continue;
@@ -854,6 +855,7 @@ Gwk::Point DirectX11::MeasureText(Gwk::Font* pFont, const Gwk::String& text)
         {
             fRowWidth = 0.0f;
             fHeight += fRowHeight;
+            continue;
         }
         else if (wide_char < BeginCharacter || wide_char > LastCharacter)
             continue;

--- a/source/platform/renderers/DirectX11/DirectX11.cpp
+++ b/source/platform/renderers/DirectX11/DirectX11.cpp
@@ -100,9 +100,9 @@ static HRESULT CompileShaderFromMemory(const char* szdata, SIZE_T len, LPCSTR sz
     //);
     ID3DBlob* pErrorBlob = nullptr;
     hr = D3DCompile(szdata, len,        // source/len
-                    nullptr,               // source name
-                    nullptr,               // defines
-                    nullptr,               // include
+                    nullptr,            // source name
+                    nullptr,            // defines
+                    nullptr,            // include
                     szEntryPoint,       // entry
                     szShaderModel,      // target
                     dwShaderFlags, 0,   // flags
@@ -121,10 +121,6 @@ static HRESULT CompileShaderFromMemory(const char* szdata, SIZE_T len, LPCSTR sz
     return S_OK;
 }
 #pragma endregion
-
-const wchar_t BeginCharacter = L' ';
-const wchar_t LastCharacter = 0x2FFF;
-const wchar_t NewLineCharacter = L'\n';
 
 class FontData
 {
@@ -150,6 +146,14 @@ public:
     ID3D11ShaderResourceView* m_Texture;
 };
 
+DirectX11ResourceLoader::~DirectX11ResourceLoader()
+{
+    for each (auto& font in m_FontDataList)
+    {
+        FontData* pFontData = static_cast<FontData*>(font);
+        delete pFontData;
+    }
+}
 
 Font::Status DirectX11ResourceLoader::LoadFont(Font& font)
 {
@@ -735,8 +739,7 @@ void DirectX11::SetDrawColor(Gwk::Color color)
     m_Color = D3DCOLOR_ARGB(color.a, color.r, color.g, color.b);
 }
 
-
-inline wchar_t utf8_to_wchart(char*& in)// Gwk::Utility::Widen too low
+static inline wchar_t utf8_to_wchart(char*& in)// Gwk::Utility::Widen too slow
 {
 
     unsigned int codepoint;
@@ -775,6 +778,9 @@ void DirectX11::RenderText(Gwk::Font* pFont, Gwk::Point pos, const Gwk::String &
     Flush();
 
     FontData* pFontData = (FontData*)pFont->data;
+
+    if (pFontData == nullptr)
+        return;
 
     Translate(pos.x, pos.y);
     XMFLOAT4A loc(pos.x, pos.y, 0, 0);
@@ -840,6 +846,8 @@ Gwk::Point DirectX11::MeasureText(Gwk::Font* pFont, const Gwk::String& text)
         return Gwk::Point(0, 0);
 
     FontData* font = (FontData*)pFont->data;
+    if (font == nullptr)
+        return Gwk::Point(0, 0);
 
     float fRowWidth = 0.0f;
     float fRowHeight = (font->m_TexCoords[0].w - font->m_TexCoords[0].y) * font->m_TexHeight;


### PR DESCRIPTION
- Added limited support for UTF-8 rendering
- Safely released save-state objects

**Before (Empty text button under 'Event Tester')**
![GWork DirectX 11 Renderer](https://user-images.githubusercontent.com/4210885/35534921-59912d54-0518-11e8-9c23-8d7ab1d8507d.png)

**After**
![Updated DirectX 11 Renderer](https://user-images.githubusercontent.com/4210885/35534980-8a42dab0-0518-11e8-8b80-bbb95f909650.png)