### PR TITLE
Fix #83 issues

### DIFF
--- a/source/platform/include/Gwork/BaseRender.h
+++ b/source/platform/include/Gwork/BaseRender.h
@@ -176,6 +176,7 @@ namespace Gwk
         protected:
 
             virtual bool EnsureFont(const Gwk::Font& font) { return false; }
+            virtual bool EnsureTexture(const Gwk::Texture& texture) { return false; }
 
             float m_fScale;
 

--- a/source/platform/include/Gwork/PlatformTypes.h
+++ b/source/platform/include/Gwork/PlatformTypes.h
@@ -252,6 +252,11 @@ namespace Gwk
             return facename == rhs.facename && size == rhs.size && bold == rhs.bold;
         }
 
+        inline bool operator!=(const Font& rhs) const
+        {
+            return  bold != rhs.bold || size != rhs.size || facename != rhs.facename;
+        }
+
         String facename;
         float size;
         bool bold;
@@ -279,6 +284,7 @@ namespace Gwk
         Texture& operator=(const Texture&) = default;
 
         inline bool operator==(const Texture& rhs) const { return name == rhs.name; }
+        inline bool operator!=(const Texture& rhs) const { return name != rhs.name; }
 
         String  name;
         bool readable;

--- a/source/platform/include/Gwork/Renderers/Allegro5.h
+++ b/source/platform/include/Gwork/Renderers/Allegro5.h
@@ -65,6 +65,7 @@ namespace Gwk
             Texture::Status LoadTexture(const Gwk::Texture& texture) override;
             void FreeTexture(const Gwk::Texture& texture) override;
             TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
         protected:// Resourses
 
             struct ALTextureData : public Gwk::TextureData
@@ -111,6 +112,8 @@ namespace Gwk
 
             std::unordered_map<Font, ALFontData> m_fonts;
             std::unordered_map<Texture, ALTextureData> m_textures;
+            std::pair<const Font, ALFontData>* m_lastFont;
+            std::pair<const Texture, ALTextureData>* m_lastTexture;
         public:
             void DrawLinedRect(Gwk::Rect rect) override;
             void DrawShavedCornerRect(Gwk::Rect rect, bool bSlight = false) override;

--- a/source/platform/include/Gwork/Renderers/Allegro5.h
+++ b/source/platform/include/Gwork/Renderers/Allegro5.h
@@ -48,12 +48,12 @@ namespace Gwk
                 float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
 
             Gwk::Color PixelColor(const Gwk::Texture& texture,
-                unsigned int x, unsigned int y,
-                const Gwk::Color& col_default) override;
+                                  unsigned int x, unsigned int y,
+                                  const Gwk::Color& col_default) override;
 
             void RenderText(const Gwk::Font& font,
-                Gwk::Point pos,
-                const Gwk::String& text) override;
+                            Gwk::Point pos,
+                            const Gwk::String& text) override;
 
             Gwk::Point MeasureText(const Gwk::Font& font, const Gwk::String& text) override;
 

--- a/source/platform/include/Gwork/Renderers/DirectX11.h
+++ b/source/platform/include/Gwork/Renderers/DirectX11.h
@@ -65,6 +65,7 @@ namespace Gwk
             Texture::Status LoadTexture(const Gwk::Texture& texture) override;
             void FreeTexture(const Gwk::Texture& texture) override;
             TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
 
         protected:
 
@@ -179,6 +180,8 @@ namespace Gwk
 
             std::unordered_map<Font, DxFontData> m_fonts;
             std::unordered_map<Texture, DxTextureData> m_textures;
+            std::pair<const Font, DxFontData>* m_lastFont;
+            std::pair<const Texture, DxTextureData>* m_lastTexture;
 
             void Flush();
             void Present();

--- a/source/platform/include/Gwork/Renderers/Irrlicht.h
+++ b/source/platform/include/Gwork/Renderers/Irrlicht.h
@@ -54,15 +54,15 @@ namespace Gwk
             void DrawPixel(int x, int y) override;
 
             void DrawTexturedRect(const Gwk::Texture& texture, Gwk::Rect targetRect, float u1 = 0.0f,
-                float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
+                                  float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
 
             Gwk::Color PixelColor(const Gwk::Texture& texture,
-                unsigned int x, unsigned int y,
-                const Gwk::Color& col_default) override;
+                                  unsigned int x, unsigned int y,
+                                  const Gwk::Color& col_default) override;
 
             void RenderText(const Gwk::Font& font,
-                Gwk::Point pos,
-                const Gwk::String& text) override;
+                            Gwk::Point pos,
+                            const Gwk::String& text) override;
 
             Gwk::Point MeasureText(const Gwk::Font& font, const Gwk::String& text) override;
 

--- a/source/platform/include/Gwork/Renderers/Irrlicht.h
+++ b/source/platform/include/Gwork/Renderers/Irrlicht.h
@@ -74,6 +74,7 @@ namespace Gwk
             Texture::Status LoadTexture(const Gwk::Texture& texture) override;
             void FreeTexture(const Gwk::Texture& texture) override;
             TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
 
         protected:// Resourses
 
@@ -122,6 +123,7 @@ namespace Gwk
 
             std::unordered_map<Font, IRFontData> m_fonts;*/
             std::unordered_map<Texture, IRTextureData> m_textures;
+            std::pair<const Texture, IRTextureData>* m_lastTexture;
             
         private:
             

--- a/source/platform/include/Gwork/Renderers/OpenGL.h
+++ b/source/platform/include/Gwork/Renderers/OpenGL.h
@@ -67,6 +67,7 @@ namespace Gwk
             Texture::Status LoadTexture(const Gwk::Texture& texture) override;
             void FreeTexture(const Gwk::Texture& texture) override;
             TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
         protected:// Resourses
 
             struct GLTextureData : public Gwk::TextureData
@@ -130,6 +131,8 @@ namespace Gwk
 
             std::unordered_map<Font, GLFontData> m_fonts;
             std::unordered_map<Texture, GLTextureData> m_textures;
+            std::pair<const Font, GLFontData>* m_lastFont;
+            std::pair<const Texture, GLTextureData>* m_lastTexture;
         protected:
 
             Rect m_viewRect;

--- a/source/platform/include/Gwork/Renderers/OpenGLCore.h
+++ b/source/platform/include/Gwork/Renderers/OpenGLCore.h
@@ -42,15 +42,15 @@ namespace Gwk
             void EndClip() override;
 
             void DrawTexturedRect(const Gwk::Texture& texture, Gwk::Rect targetRect, float u1 = 0.0f,
-                float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
+                                  float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
 
             Gwk::Color PixelColor(const Gwk::Texture& texture,
-                unsigned int x, unsigned int y,
-                const Gwk::Color& col_default) override;
+                                  unsigned int x, unsigned int y,
+                                  const Gwk::Color& col_default) override;
 
             void RenderText(const Gwk::Font& font,
-                Gwk::Point pos,
-                const Gwk::String& text) override;
+                            Gwk::Point pos,
+                            const Gwk::String& text) override;
 
             Gwk::Point MeasureText(const Gwk::Font& font, const Gwk::String& text) override;
 

--- a/source/platform/include/Gwork/Renderers/OpenGLCore.h
+++ b/source/platform/include/Gwork/Renderers/OpenGLCore.h
@@ -62,6 +62,7 @@ namespace Gwk
             Texture::Status LoadTexture(const Gwk::Texture& texture) override;
             void FreeTexture(const Gwk::Texture& texture) override;
             TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
 
         protected:// Resourses
 
@@ -119,13 +120,15 @@ namespace Gwk
 
                 float   m_Spacing;
 
-                float width;
-                float height;
+                int width;
+                int height;
                 unsigned int texture_id;
             };
 
             std::unordered_map<Font, GLFontData> m_fonts;
             std::unordered_map<Texture, GLTextureData> m_textures;
+            std::pair<const Font, GLFontData>* m_lastFont;
+            std::pair<const Texture, GLTextureData>* m_lastTexture;
         public:
 
             bool InitializeContext(Gwk::WindowProvider* window) override;

--- a/source/platform/include/Gwork/Renderers/SDL2.h
+++ b/source/platform/include/Gwork/Renderers/SDL2.h
@@ -53,15 +53,15 @@ namespace Gwk
             void EndClip() override;
 
             void DrawTexturedRect(const Gwk::Texture& texture, Gwk::Rect targetRect, float u1 = 0.0f,
-                float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
+                                  float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
 
             Gwk::Color PixelColor(const Gwk::Texture& texture,
-                unsigned int x, unsigned int y,
-                const Gwk::Color& col_default) override;
+                                  unsigned int x, unsigned int y,
+                                  const Gwk::Color& col_default) override;
 
             void RenderText(const Gwk::Font& font,
-                Gwk::Point pos,
-                const Gwk::String& text) override;
+                            Gwk::Point pos,
+                            const Gwk::String& text) override;
 
             Gwk::Point MeasureText(const Gwk::Font& font, const Gwk::String& text) override;
 

--- a/source/platform/include/Gwork/Renderers/SDL2.h
+++ b/source/platform/include/Gwork/Renderers/SDL2.h
@@ -73,6 +73,7 @@ namespace Gwk
             Texture::Status LoadTexture(const Gwk::Texture& texture) override;
             void FreeTexture(const Gwk::Texture& texture) override;
             TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
 
         protected:// Resourses
 
@@ -122,6 +123,8 @@ namespace Gwk
 
             std::unordered_map<Font, SDL2FontData> m_fonts;
             std::unordered_map<Texture, SDL2TextureData> m_textures;
+            std::pair<const Font, SDL2FontData>* m_lastFont;
+            std::pair<const Texture, SDL2TextureData>* m_lastTexture;
         public:
 
             bool BeginContext(Gwk::WindowProvider* window) override;

--- a/source/platform/include/Gwork/Renderers/SFML2.h
+++ b/source/platform/include/Gwork/Renderers/SFML2.h
@@ -14,43 +14,37 @@
 #include <SFML/Graphics/RenderTarget.hpp>
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
+
+#include <unordered_map>
+#include <memory>
+#include <vector>
+#include <functional>
 
 namespace Gwk
 {
     namespace Renderer
     {
-        //! Default resource loader for SFML2.
-        class SFML2ResourceLoader : public ResourceLoader
-        {
-            ResourcePaths& m_paths;
-        public:
-            SFML2ResourceLoader(ResourcePaths& paths)
-            :   m_paths(paths)
-            {}
-
-            Font::Status LoadFont(Font& font) override;
-            void FreeFont(Font& font) override;
-
-            Texture::Status LoadTexture(Texture& texture) override;
-            void FreeTexture(Texture& texture) override;
-        };
 
         //
         //! Renderer for [SFML2](https://www.sfml-dev.org/).
         //
         class GWK_EXPORT SFML2 : public Gwk::Renderer::Base
         {
+            template<typename T>
+            using deleted_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
+
         public:
 
             //! Constructor for SFML2 renderer.
             //! \param loader : ResourceLoader for renderer.
             //! \param target : application render target.
-            SFML2(ResourceLoader& loader, sf::RenderTarget& target);
+            SFML2(ResourcePaths& paths, sf::RenderTarget& target);
 
             virtual ~SFML2();
 
-            inline void EnsurePrimitiveType(sf::PrimitiveType type)
+            inline void SetPrimitiveType(sf::PrimitiveType type)
             {
                 if (m_buffer.getPrimitiveType() != type)
                 {
@@ -59,7 +53,7 @@ namespace Gwk
                 }
             }
 
-            inline void EnsureTexture(const sf::Texture *texture)
+            inline void SetTexture(const sf::Texture *texture)
             {
                 if (m_renderStates.texture != texture)
                 {
@@ -99,16 +93,80 @@ namespace Gwk
             void DrawLinedRect(Gwk::Rect rect) override;
             void DrawFilledRect(Gwk::Rect rect) override;
             void DrawShavedCornerRect(Gwk::Rect rect, bool bSlight = false) override;
-            void DrawTexturedRect(Gwk::Texture* texture,
-                                  Gwk::Rect rect,
-                                  float u1, float v1, float u2, float v2) override;
 
-            void RenderText(Gwk::Font* font, Gwk::Point pos, const Gwk::String& text) override;
-            Gwk::Point MeasureText(Gwk::Font* font, const Gwk::String& text) override;
+            void DrawTexturedRect(const Gwk::Texture& texture, Gwk::Rect targetRect, float u1 = 0.0f,
+                float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
 
-            Gwk::Color PixelColor(Gwk::Texture* texture,
-                                  unsigned int x, unsigned int y,
-                                  const Gwk::Color& col_default) override;
+            Gwk::Color PixelColor(const Gwk::Texture& texture,
+                unsigned int x, unsigned int y,
+                const Gwk::Color& col_default) override;
+
+            void RenderText(const Gwk::Font& font,
+                Gwk::Point pos,
+                const Gwk::String& text) override;
+
+            Gwk::Point MeasureText(const Gwk::Font& font, const Gwk::String& text) override;
+
+            // Resource Loader
+            Gwk::Font::Status LoadFont(const Gwk::Font& font) override;
+            void FreeFont(const Gwk::Font& font) override;
+            bool EnsureFont(const Gwk::Font& font) override;
+
+            Texture::Status LoadTexture(const Gwk::Texture& texture) override;
+            void FreeTexture(const Gwk::Texture& texture) override;
+            TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
+        protected:// Resourses
+
+            struct SFMLTextureData : public Gwk::TextureData
+            {
+                SFMLTextureData()
+                {
+                }
+                SFMLTextureData(const SFMLTextureData&) = delete;
+                SFMLTextureData(SFMLTextureData&& other)
+                    : SFMLTextureData()
+                {
+                    std::swap(width, other.width);
+                    std::swap(height, other.height);
+                    std::swap(readable, other.readable);
+
+                    texture.swap(other.texture);
+                    image.swap(other.image);
+                }
+
+                ~SFMLTextureData()
+                {
+                }
+
+                std::unique_ptr<sf::Texture> texture;
+                std::unique_ptr<sf::Image> image;
+            };
+
+            struct SFMLFontData
+            {
+                SFMLFontData()
+                {
+                }
+
+                SFMLFontData(const SFMLFontData&) = delete;
+                SFMLFontData(SFMLFontData&& other)
+                    : SFMLFontData()
+                {
+                    font.swap(other.font);
+                }
+
+                ~SFMLFontData()
+                {
+                }
+
+                std::unique_ptr<sf::Font> font;
+            };
+
+            std::unordered_map<Font, SFMLFontData> m_fonts;
+            std::unordered_map<Texture, SFMLTextureData> m_textures;
+            std::pair<const Font, SFMLFontData>* m_lastFont;
+            std::pair<const Texture, SFMLTextureData>* m_lastTexture;
 
         protected:
 

--- a/source/platform/include/Gwork/Renderers/SFML2.h
+++ b/source/platform/include/Gwork/Renderers/SFML2.h
@@ -95,15 +95,15 @@ namespace Gwk
             void DrawShavedCornerRect(Gwk::Rect rect, bool bSlight = false) override;
 
             void DrawTexturedRect(const Gwk::Texture& texture, Gwk::Rect targetRect, float u1 = 0.0f,
-                float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
+                                  float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
 
             Gwk::Color PixelColor(const Gwk::Texture& texture,
-                unsigned int x, unsigned int y,
-                const Gwk::Color& col_default) override;
+                                  unsigned int x, unsigned int y,
+                                  const Gwk::Color& col_default) override;
 
             void RenderText(const Gwk::Font& font,
-                Gwk::Point pos,
-                const Gwk::String& text) override;
+                            Gwk::Point pos,
+                            const Gwk::String& text) override;
 
             Gwk::Point MeasureText(const Gwk::Font& font, const Gwk::String& text) override;
 

--- a/source/platform/include/Gwork/Renderers/Software.h
+++ b/source/platform/include/Gwork/Renderers/Software.h
@@ -122,15 +122,13 @@ namespace Gwk
 
                 Color& At(int x, int y)
                 {
-                    unsigned char* color_ptr = m_ReadData.get() + (y * 4 * static_cast<int>(width) + x * 4);
-                    return *reinterpret_cast<Color*>(color_ptr);
+                    return reinterpret_cast<Color*>(m_ReadData.get())[y * static_cast<int>(width) + x];
                 }
                 Color& At(Point const& pt) { return At(pt.x, pt.y); }
 
                 const Color& At(int x, int y) const
                 {
-                    unsigned char* color_ptr = m_ReadData.get() + (y * 4 * static_cast<int>(width) + x * 4);
-                    return *reinterpret_cast<Color*>(color_ptr);
+                    return reinterpret_cast<Color*>(m_ReadData.get())[y * static_cast<int>(width) + x];
                 }
                 const Color& At(Point const& pt) const { return At(pt.x, pt.y); }
 

--- a/source/platform/include/Gwork/Renderers/Software.h
+++ b/source/platform/include/Gwork/Renderers/Software.h
@@ -93,6 +93,7 @@ namespace Gwk
             Texture::Status LoadTexture(const Gwk::Texture& texture) override;
             void FreeTexture(const Gwk::Texture& texture) override;
             TextureData GetTextureData(const Gwk::Texture& texture) const override;
+            bool EnsureTexture(const Gwk::Texture& texture) override;
             
         protected:// Resourses
 
@@ -121,13 +122,15 @@ namespace Gwk
 
                 Color& At(int x, int y)
                 {
-                    return (reinterpret_cast<Color*>(m_ReadData.get()))[y * static_cast<int>(width) + x];
+                    unsigned char* color_ptr = m_ReadData.get() + (y * 4 * static_cast<int>(width) + x * 4);
+                    return *reinterpret_cast<Color*>(color_ptr);
                 }
                 Color& At(Point const& pt) { return At(pt.x, pt.y); }
 
                 const Color& At(int x, int y) const
                 {
-                    return (reinterpret_cast<Color*>(m_ReadData.get()))[y * static_cast<int>(width) + x];
+                    unsigned char* color_ptr = m_ReadData.get() + (y * 4 * static_cast<int>(width) + x * 4);
+                    return *reinterpret_cast<Color*>(color_ptr);
                 }
                 const Color& At(Point const& pt) const { return At(pt.x, pt.y); }
 
@@ -172,6 +175,8 @@ namespace Gwk
 
             std::unordered_map<Font, SWFontData> m_fonts;
             std::unordered_map<Texture, SWTextureData> m_textures;
+            std::pair<const Font, SWFontData>* m_lastFont;
+            std::pair<const Texture, SWTextureData>* m_lastTexture;
             
         public:
 

--- a/source/platform/include/Gwork/Renderers/Software.h
+++ b/source/platform/include/Gwork/Renderers/Software.h
@@ -73,15 +73,15 @@ namespace Gwk
             void DrawPixel(int x, int y) override;
 
             void DrawTexturedRect(const Gwk::Texture& texture, Gwk::Rect targetRect, float u1 = 0.0f,
-                float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
+                                  float v1 = 0.0f, float u2 = 1.0f, float v2 = 1.0f) override;
 
             Gwk::Color PixelColor(const Gwk::Texture& texture,
-                unsigned int x, unsigned int y,
-                const Gwk::Color& col_default) override;
+                                  unsigned int x, unsigned int y,
+                                  const Gwk::Color& col_default) override;
 
             void RenderText(const Gwk::Font& font,
-                Gwk::Point pos,
-                const Gwk::String& text) override;
+                            Gwk::Point pos,
+                            const Gwk::String& text) override;
 
             Gwk::Point MeasureText(const Gwk::Font& font, const Gwk::String& text) override;
 

--- a/source/platform/include/Gwork/Utility.h
+++ b/source/platform/include/Gwork/Utility.h
@@ -87,7 +87,7 @@ namespace Gwk
 
             static inline wchar_t utf8_to_wchart(char*& in)// Gwk::Utility::Widen too slow
             {
-#if defined(__clang__) && defined(__apple_build_version__) && __apple_build_version__ < 8
+#if defined(__clang__) && defined(__apple_build_version__) && __apple_build_version__ >= 8
                 // thread_local not supported on Xcode versions below 8
                 static unsigned int next = 0x10000;
 #else

--- a/source/platform/include/Gwork/Utility.h
+++ b/source/platform/include/Gwork/Utility.h
@@ -87,7 +87,15 @@ namespace Gwk
 
             static inline wchar_t utf8_to_wchart(char*& in)// Gwk::Utility::Widen too slow
             {
+                thread_local static unsigned int next = 0x10000;
+                if (next != 0x10000)
+                {
+                    wchar_t ret = static_cast<wchar_t>(next);
+                    next = 0x10000;
+                    return ret;
+                }
                 unsigned int codepoint;
+
                 while (*in != 0)
                 {
                     unsigned char ch = static_cast<unsigned char>(*in);
@@ -108,11 +116,11 @@ namespace Gwk
                             return static_cast<wchar_t>(codepoint);
                         else if (codepoint > 0xffff)
                         {
+                            next = static_cast<wchar_t>(0xdc00 + (codepoint & 0x03ff));
                             return static_cast<wchar_t>(0xd800 + (codepoint >> 10));
-                            return static_cast<wchar_t>(0xdc00 + (codepoint & 0x03ff));
                         }
                         else if (codepoint < 0xd800 || codepoint >= 0xe000)
-                            return 1, static_cast<wchar_t>(codepoint);
+                            return static_cast<wchar_t>(codepoint);
                     }
                 }
                 return 0;

--- a/source/platform/include/Gwork/Utility.h
+++ b/source/platform/include/Gwork/Utility.h
@@ -87,7 +87,12 @@ namespace Gwk
 
             static inline wchar_t utf8_to_wchart(char*& in)// Gwk::Utility::Widen too slow
             {
+#if defined(__clang__) && defined(__apple_build_version__) && __apple_build_version__ < 8
+                // thread_local not supported on Xcode versions below 8
+                static unsigned int next = 0x10000;
+#else
                 thread_local static unsigned int next = 0x10000;
+#endif
                 if (next != 0x10000)
                 {
                     wchar_t ret = static_cast<wchar_t>(next);

--- a/source/platform/renderers/Irrlicht/Irrlicht.cpp
+++ b/source/platform/renderers/Irrlicht/Irrlicht.cpp
@@ -1,8 +1,8 @@
 /*
- *  Gwork
- *  Copyright (c) 2013-2017 Billy Quith
- *  See license in Gwork.h
- */
+*  Gwork
+*  Copyright (c) 2013-2017 Billy Quith
+*  See license in Gwork.h
+*/
 
 #include <Gwork/Renderers/Irrlicht.h>
 
@@ -12,304 +12,324 @@
 #include <map>
 
 namespace Gwk {
-namespace Renderer {
+    namespace Renderer {
 
-// Resource Loader
-Font::Status Irrlicht::LoadFont(const Gwk::Font& font)
-{
-    return Font::Status::Loaded;
-}
-
-void Irrlicht::FreeFont(const Gwk::Font& font)
-{
-}
-
-bool Irrlicht::EnsureFont(const Gwk::Font& font)
-{
-    return LoadFont(font) == Font::Status::Loaded;
-}
-
-Texture::Status Irrlicht::LoadTexture(const Gwk::Texture& texture)
-{
-    FreeTexture(texture);
-
-    const String filename = GetResourcePaths().GetPath(ResourcePaths::Type::Texture, texture.name);
-
-    irr::video::ITexture* NewTex = Driver->getTexture(filename.c_str());
-    if (!NewTex)
-    {
-        return Texture::Status::ErrorFileNotFound;
-    }
-    else
-    {
-        IRTextureData texData;
-
-        const irr::core::dimension2d<irr::u32> TexSize = NewTex->getSize();
-        texData.texture = deleted_unique_ptr<irr::video::ITexture>(NewTex, [this](irr::video::ITexture* mem) { if (mem) Driver->removeTexture(mem); });
-        texData.readable = false;
-        texData.width = TexSize.Width;
-        texData.height = TexSize.Height;
-        m_textures.insert(std::make_pair(texture, std::move(texData)));
-        return Texture::Status::Loaded;
-    }
-}
-
-void Irrlicht::FreeTexture(const Gwk::Texture& texture)
-{
-    m_textures.erase(texture); // calls IRTextureData destructor
-}
-
-TextureData Irrlicht::GetTextureData(const Texture& texture) const
-{
-    auto it = m_textures.find(texture);
-    if (it != m_textures.cend())
-    {
-        return it->second;
-    }
-    // Texture not loaded :(
-    return TextureData();
-}
-
-//
-//  Irrlicht ICacheToTexture
-//
-class IrrlichtCTT : public Gwk::Renderer::ICacheToTexture
-{
-private:
-    Gwk::Renderer::Base *m_renderer;
-
-    irr::video::IVideoDriver* m_Driver;
-    std::map<CacheHandle, irr::video::ITexture*> m_TextureCache;
-
-public:
-    IrrlichtCTT(irr::video::IVideoDriver* VideoDriver) : m_Driver(VideoDriver) {}
-
-    ~IrrlichtCTT()
-    {
-        //  Cleanup all cached textures
-        for (auto it : m_TextureCache)
+        // Resource Loader
+        Font::Status Irrlicht::LoadFont(const Gwk::Font& font)
         {
-            m_Driver->removeTexture(it.second);
+            return Font::Status::Loaded;
         }
-    }
 
-    void SetRenderer(Gwk::Renderer::Base* renderer) { m_renderer = renderer; }
-
-    void Initialize() {}
-    void ShutDown() {}
-
-    //
-    //  Create this controls cached texture if it doesn't already exist
-    void CreateControlCacheTexture(CacheHandle control, const Point& size)
-    {
-        if (m_TextureCache.find(control) == m_TextureCache.end())
+        void Irrlicht::FreeFont(const Gwk::Font& font)
         {
-            irr::video::ITexture* RTT =
-                m_Driver->addRenderTargetTexture(
-                    irr::core::dimension2d<irr::u32>(size.x, size.y));
-            m_TextureCache.insert(std::pair<CacheHandle, irr::video::ITexture*>(control, RTT));
         }
-    }
 
-    //  Setup Irrlicht to cache this control to a texture
-    void SetupCacheTexture(CacheHandle control)
-    {
-        auto it = m_TextureCache.find(control);
-        if (it != m_TextureCache.end())
+        bool Irrlicht::EnsureFont(const Gwk::Font& font)
         {
-            m_Driver->setRenderTarget((*it).second);
+            return LoadFont(font) == Font::Status::Loaded;
         }
-    }
 
-    //  Revert Irrlicht's render target
-    void FinishCacheTexture(CacheHandle control)
-    {
-        m_Driver->setRenderTarget(NULL);
-    }
-
-    //  Draw this controls cached texture
-    void DrawCachedControlTexture(CacheHandle control)
-    {
-        auto it = m_TextureCache.find(control);
-        if (it != m_TextureCache.end())
+        Texture::Status Irrlicht::LoadTexture(const Gwk::Texture& texture)
         {
-            const Gwk::Point &pos = m_renderer->GetRenderOffset();
-            m_Driver->draw2DImage((*it).second,
-                irr::core::vector2di(pos.x, pos.y),
-                irr::core::rect<irr::s32>(irr::core::dimension2d<irr::s32>(0, 0),
-                (*it).second->getSize()),
-                NULL,
-                irr::video::SColor(255, 255, 255, 255),
+            FreeTexture(texture);
+            m_lastTexture = nullptr;
+
+            const String filename = GetResourcePaths().GetPath(ResourcePaths::Type::Texture, texture.name);
+
+            irr::video::ITexture* NewTex = Driver->getTexture(filename.c_str());
+            if (!NewTex)
+            {
+                return Texture::Status::ErrorFileNotFound;
+            }
+            else
+            {
+                IRTextureData texData;
+
+                const irr::core::dimension2d<irr::u32> TexSize = NewTex->getSize();
+                texData.texture = deleted_unique_ptr<irr::video::ITexture>(NewTex, [this](irr::video::ITexture* mem) { if (mem) Driver->removeTexture(mem); });
+                texData.readable = false;
+                texData.width = TexSize.Width;
+                texData.height = TexSize.Height;
+                m_lastTexture = &(*m_textures.insert(std::make_pair(texture, std::move(texData))).first);
+                return Texture::Status::Loaded;
+            }
+        }
+
+        void Irrlicht::FreeTexture(const Gwk::Texture& texture)
+        {
+            if (m_lastTexture != nullptr && m_lastTexture->first == texture)
+                m_lastTexture = nullptr;
+
+            m_textures.erase(texture); // calls IRTextureData destructor
+        }
+
+        TextureData Irrlicht::GetTextureData(const Texture& texture) const
+        {
+            if (m_lastTexture != nullptr && m_lastTexture->first == texture)
+                return m_lastTexture->second;
+
+            auto it = m_textures.find(texture);
+            if (it != m_textures.cend())
+            {
+                return it->second;
+            }
+            // Texture not loaded :(
+            return TextureData();
+        }
+
+        bool Irrlicht::EnsureTexture(const Gwk::Texture& texture)
+        {
+            if (m_lastTexture != nullptr)
+            {
+                if (m_lastTexture->first == texture)
+                    return true;
+            }
+
+            // Was it loaded before?
+            auto it = m_textures.find(texture);
+            if (it != m_textures.end())
+            {
+                m_lastTexture = &(*it);
+                return true;
+            }
+
+            // No, try load to it
+
+            // LoadTexture sets m_lastTexture, if exist
+            return LoadTexture(texture) == Texture::Status::Loaded;
+        }
+
+        //
+        //  Irrlicht ICacheToTexture
+        //
+        class IrrlichtCTT : public Gwk::Renderer::ICacheToTexture
+        {
+        private:
+            Gwk::Renderer::Base *m_renderer;
+
+            irr::video::IVideoDriver* m_Driver;
+            std::map<CacheHandle, irr::video::ITexture*> m_TextureCache;
+
+        public:
+            IrrlichtCTT(irr::video::IVideoDriver* VideoDriver) : m_Driver(VideoDriver) {}
+
+            ~IrrlichtCTT()
+            {
+                //  Cleanup all cached textures
+                for (auto it : m_TextureCache)
+                {
+                    m_Driver->removeTexture(it.second);
+                }
+            }
+
+            void SetRenderer(Gwk::Renderer::Base* renderer) { m_renderer = renderer; }
+
+            void Initialize() {}
+            void ShutDown() {}
+
+            //
+            //  Create this controls cached texture if it doesn't already exist
+            void CreateControlCacheTexture(CacheHandle control, const Point& size)
+            {
+                if (m_TextureCache.find(control) == m_TextureCache.end())
+                {
+                    irr::video::ITexture* RTT =
+                        m_Driver->addRenderTargetTexture(
+                            irr::core::dimension2d<irr::u32>(size.x, size.y));
+                    m_TextureCache.insert(std::pair<CacheHandle, irr::video::ITexture*>(control, RTT));
+                }
+            }
+
+            //  Setup Irrlicht to cache this control to a texture
+            void SetupCacheTexture(CacheHandle control)
+            {
+                auto it = m_TextureCache.find(control);
+                if (it != m_TextureCache.end())
+                {
+                    m_Driver->setRenderTarget((*it).second);
+                }
+            }
+
+            //  Revert Irrlicht's render target
+            void FinishCacheTexture(CacheHandle control)
+            {
+                m_Driver->setRenderTarget(NULL);
+            }
+
+            //  Draw this controls cached texture
+            void DrawCachedControlTexture(CacheHandle control)
+            {
+                auto it = m_TextureCache.find(control);
+                if (it != m_TextureCache.end())
+                {
+                    const Gwk::Point &pos = m_renderer->GetRenderOffset();
+                    m_Driver->draw2DImage((*it).second,
+                        irr::core::vector2di(pos.x, pos.y),
+                        irr::core::rect<irr::s32>(irr::core::dimension2d<irr::s32>(0, 0),
+                        (*it).second->getSize()),
+                        NULL,
+                        irr::video::SColor(255, 255, 255, 255),
+                        true);
+                }
+            }
+
+            void UpdateControlCacheTexture(CacheHandle control) {}
+        };
+
+
+        //
+        //  Irrlicht Renderer
+        //
+        Irrlicht::Irrlicht(ResourcePaths& paths, irr::IrrlichtDevice* Device)
+            : Base(paths)
+            , m_CTT(new IrrlichtCTT(Device->getVideoDriver()))
+            , Driver(Device->getVideoDriver())
+            , m_lastTexture(nullptr)
+        {
+            m_CTT->SetRenderer(this);
+            m_CTT->Initialize();
+            DrawColor.set(255, 255, 255, 255);
+            ClipRect = irr::core::rect<irr::s32>();
+            Text = Device->getGUIEnvironment()->getBuiltInFont();
+        }
+
+        Irrlicht::~Irrlicht()
+        {
+            delete m_CTT;
+        }
+
+        void Irrlicht::SetDrawColor(Gwk::Color color)
+        {
+            DrawColor.set((irr::u32)color.a, (irr::u32)color.r, (irr::u32)color.g, (irr::u32)color.b);
+        }
+
+        void Irrlicht::StartClip()
+        {
+            const Gwk::Rect rect = ClipRegion();
+            ClipRect.UpperLeftCorner = irr::core::vector2di(rect.x, rect.y);
+            ClipRect.LowerRightCorner = irr::core::vector2di(rect.x + rect.w, rect.y + rect.h);
+        }
+
+        void Irrlicht::EndClip()
+        {
+            ClipRect.UpperLeftCorner = irr::core::vector2di(0, 0);
+            ClipRect.LowerRightCorner = irr::core::vector2di(0, 0);
+        }
+
+
+        Gwk::Color Irrlicht::PixelColor(const Gwk::Texture& texture,
+            unsigned int x, unsigned int y, const Gwk::Color& col_default)
+        {
+
+            if (!EnsureTexture(texture))
+                return col_default;
+
+            IRTextureData& texData = m_lastTexture->second;
+
+            irr::video::ITexture* Texture = texData.texture.get();
+
+            const irr::u32 pitch = Texture->getPitch();
+            const irr::video::ECOLOR_FORMAT format = Texture->getColorFormat();
+            const irr::u32 bytes = irr::video::IImage::getBitsPerPixelFromFormat(format) / 8;
+
+            if (!texData.readable)
+            {
+
+                unsigned char* buffer = (unsigned char*)Texture->lock();
+                if (buffer)
+                {
+                    texData.m_ReadData = deleted_unique_ptr<unsigned char>(
+                        new unsigned char[texData.width * texData.height * bytes],
+                        [](unsigned char* mem) { if (mem) delete[](mem); });
+                    memcpy(texData.m_ReadData.get(), buffer, texData.width * texData.height * bytes);
+                    texData.readable = true;
+                    const irr::video::SColor pixelColor = irr::video::SColor(*(unsigned int*)(buffer + (y * pitch) + (x*bytes)));
+                    Texture->unlock();
+                    return Gwk::Color(pixelColor.getRed(),
+                        pixelColor.getGreen(),
+                        pixelColor.getBlue(),
+                        pixelColor.getAlpha());
+                }
+            }
+            else
+            {
+
+                const irr::video::SColor pixelColor = irr::video::SColor(*(unsigned int*)(texData.m_ReadData.get() + (y * pitch) + (x*bytes)));
+                return Gwk::Color(pixelColor.getRed(),
+                    pixelColor.getGreen(),
+                    pixelColor.getBlue(),
+                    pixelColor.getAlpha());
+            }
+            return col_default;
+        }
+
+        void Irrlicht::RenderText(const Gwk::Font& font, Gwk::Point pos, const Gwk::String & text)
+        {
+            Translate(pos.x, pos.y);
+            Text->draw(text.c_str(),
+                irr::core::rect<irr::s32>(pos.x, pos.y, pos.x, pos.y),
+                DrawColor,
+                false,
+                false,
+                &ClipRect);
+        }
+
+        Gwk::Point Irrlicht::MeasureText(const Gwk::Font& font, const Gwk::String & text)
+        {
+            // Get size of string from Irrlicht (hopefully correct for TTF stuff)
+            const std::wstring wText(text.begin(), text.end());
+            const irr::core::dimension2d<irr::u32> irrDimension = Text->getDimension(wText.c_str());
+
+            return Gwk::Point(irrDimension.Width, irrDimension.Height);;
+        }
+
+        void Irrlicht::DrawTexturedRect(const Gwk::Texture& texture,
+            Gwk::Rect pTargetRect,
+            float u1, float v1, float u2, float v2)
+        {
+            if (!EnsureTexture(texture))
+                return DrawMissingImage(pTargetRect);
+
+            Translate(pTargetRect);
+
+            IRTextureData& texData = m_lastTexture->second;
+
+            const unsigned int w = texData.width;
+            const unsigned int h = texData.height;
+
+            Driver->draw2DImage(texData.texture.get(),
+                irr::core::rect<irr::s32>(pTargetRect.x,
+                    pTargetRect.y,
+                    pTargetRect.x + pTargetRect.w,
+                    pTargetRect.y + pTargetRect.h),
+                irr::core::rect<irr::s32>(u1*w, v1*h, u2*w, v2*h),
+                &ClipRect,
+                0,
                 true);
         }
-    }
 
-    void UpdateControlCacheTexture(CacheHandle control) {}
-};
-
-
-//
-//  Irrlicht Renderer
-//
-Irrlicht::Irrlicht(ResourcePaths& paths, irr::IrrlichtDevice* Device)
-    :   Base(paths)
-    ,   m_CTT(new IrrlichtCTT(Device->getVideoDriver()))
-    ,   Driver(Device->getVideoDriver())
-{
-    m_CTT->SetRenderer(this);
-    m_CTT->Initialize();
-    DrawColor.set(255, 255, 255, 255);
-    ClipRect = irr::core::rect<irr::s32>();
-    Text = Device->getGUIEnvironment()->getBuiltInFont();
-}
-
-Irrlicht::~Irrlicht()
-{
-    delete m_CTT;
-}
-
-void Irrlicht::SetDrawColor(Gwk::Color color)
-{
-    DrawColor.set((irr::u32)color.a, (irr::u32)color.r, (irr::u32)color.g, (irr::u32)color.b);
-}
-
-void Irrlicht::StartClip()
-{
-    const Gwk::Rect rect = ClipRegion();
-    ClipRect.UpperLeftCorner = irr::core::vector2di(rect.x, rect.y);
-    ClipRect.LowerRightCorner = irr::core::vector2di(rect.x + rect.w, rect.y + rect.h);
-}
-
-void Irrlicht::EndClip()
-{
-    ClipRect.UpperLeftCorner = irr::core::vector2di(0, 0);
-    ClipRect.LowerRightCorner = irr::core::vector2di(0, 0);
-}
-
-
-Gwk::Color Irrlicht::PixelColor(const Gwk::Texture& texture,
-                                unsigned int x, unsigned int y, const Gwk::Color& col_default)
-{
-    auto it = m_textures.find(texture);
-    if (it == m_textures.cend())
-    {
-        if (LoadTexture(texture) != Texture::Status::Loaded)
-            return col_default;
-
-        it = m_textures.find(texture);
-    }
-
-    IRTextureData& texData = it->second;
-
-    irr::video::ITexture* Texture = texData.texture.get();
-
-    const irr::u32 pitch = Texture->getPitch();
-    const irr::video::ECOLOR_FORMAT format = Texture->getColorFormat();
-    const irr::u32 bytes = irr::video::IImage::getBitsPerPixelFromFormat(format) / 8;
-
-    if (!texData.readable)
-    {
-
-        unsigned char* buffer = (unsigned char*)Texture->lock();
-        if (buffer)
+        void Irrlicht::DrawFilledRect(Gwk::Rect rect)
         {
-            texData.m_ReadData = deleted_unique_ptr<unsigned char>(new unsigned char[texData.width * texData.height * bytes], [](unsigned char* mem) { if (mem) delete[](mem); });
-            memcpy(texData.m_ReadData.get(), buffer, texData.width * texData.height * bytes);
-            texData.readable = true;
-            const irr::video::SColor pixelColor = irr::video::SColor(*(unsigned int*)(buffer + (y * pitch) + (x*bytes)));
-            Texture->unlock();
-            return Gwk::Color(pixelColor.getRed(),
-                              pixelColor.getGreen(),
-                              pixelColor.getBlue(),
-                              pixelColor.getAlpha());
+            Translate(rect);
+            Driver->draw2DRectangle(DrawColor,
+                irr::core::rect<irr::s32>(rect.x, rect.y, rect.x + rect.w, rect.y + rect.h), &ClipRect);
         }
+
+        void Irrlicht::DrawLinedRect(Gwk::Rect rect)
+        {
+            Translate(rect);
+            Driver->draw2DRectangleOutline(
+                irr::core::rect<irr::s32>(rect.x, rect.y, rect.x + rect.w, rect.y + rect.h),
+                DrawColor);
+        }
+
+        void Irrlicht::DrawPixel(int x, int y)
+        {
+            Translate(x, y);
+            Driver->drawPixel(x, y, DrawColor);
+        }
+
+        ICacheToTexture* Irrlicht::GetCTT() { return m_CTT; }
+
     }
-    else
-    {
-
-        const irr::video::SColor pixelColor = irr::video::SColor(*(unsigned int*)(texData.m_ReadData.get() + (y * pitch) + (x*bytes)));
-        return Gwk::Color(pixelColor.getRed(),
-            pixelColor.getGreen(),
-            pixelColor.getBlue(),
-            pixelColor.getAlpha());
-    }
-    return col_default;
-}
-
-void Irrlicht::RenderText(const Gwk::Font& font, Gwk::Point pos, const Gwk::String & text)
-{
-    Translate(pos.x, pos.y);
-    Text->draw(text.c_str(),
-        irr::core::rect<irr::s32>(pos.x, pos.y, pos.x, pos.y),
-        DrawColor,
-        false,
-        false,
-        &ClipRect);
-}
-
-Gwk::Point Irrlicht::MeasureText(const Gwk::Font& font, const Gwk::String & text)
-{
-    // Get size of string from Irrlicht (hopefully correct for TTF stuff)
-    const std::wstring wText(text.begin(), text.end());
-    const irr::core::dimension2d<irr::u32> irrDimension = Text->getDimension(wText.c_str());
-
-    return Gwk::Point(irrDimension.Width, irrDimension.Height);;
-}
-
-void Irrlicht::DrawTexturedRect(const Gwk::Texture& texture,
-    Gwk::Rect pTargetRect,
-    float u1, float v1, float u2, float v2)
-{
-    Translate(pTargetRect);
-
-    auto it = m_textures.find(texture);
-    if (it == m_textures.cend())
-    {
-        if (LoadTexture(texture) != Texture::Status::Loaded)
-            return DrawMissingImage(pTargetRect);
-
-        it = m_textures.find(texture);
-    }
-
-    IRTextureData& texData = it->second;
-
-    const unsigned int w = texData.width;
-    const unsigned int h = texData.height;
-
-    Driver->draw2DImage(texData.texture.get(),
-        irr::core::rect<irr::s32>(pTargetRect.x,
-            pTargetRect.y,
-            pTargetRect.x + pTargetRect.w,
-            pTargetRect.y + pTargetRect.h),
-        irr::core::rect<irr::s32>(u1*w, v1*h, u2*w, v2*h),
-        &ClipRect,
-        0,
-        true);
-
-}
-
-void Irrlicht::DrawFilledRect(Gwk::Rect rect)
-{
-    Translate(rect);
-    Driver->draw2DRectangle(DrawColor,
-        irr::core::rect<irr::s32>(rect.x, rect.y, rect.x + rect.w, rect.y + rect.h), &ClipRect);
-}
-
-void Irrlicht::DrawLinedRect(Gwk::Rect rect)
-{
-    Translate(rect);
-    Driver->draw2DRectangleOutline(
-        irr::core::rect<irr::s32>(rect.x, rect.y, rect.x + rect.w, rect.y + rect.h),
-        DrawColor);
-}
-
-void Irrlicht::DrawPixel(int x, int y)
-{
-    Translate(x, y);
-    Driver->drawPixel(x, y, DrawColor);
-}
-
-ICacheToTexture* Irrlicht::GetCTT() { return m_CTT; }
-
-}
 }

--- a/source/platform/renderers/OpenGLCore/OpenGLCore.cpp
+++ b/source/platform/renderers/OpenGLCore/OpenGLCore.cpp
@@ -529,7 +529,7 @@ void OpenGLCore::DrawTexturedRect(const Gwk::Texture& texture, Gwk::Rect rect,
 }
 
 Gwk::Color OpenGLCore::PixelColor(const Gwk::Texture& texture, unsigned int x, unsigned int y,
-    const Gwk::Color& col_default)
+                                    const Gwk::Color& col_default)
 {
     if (!EnsureTexture(texture))
         return col_default;
@@ -555,7 +555,7 @@ Gwk::Color OpenGLCore::PixelColor(const Gwk::Texture& texture, unsigned int x, u
 }
 
 void OpenGLCore::RenderText(const Gwk::Font& font, Gwk::Point pos,
-    const Gwk::String& text)
+                            const Gwk::String& text)
 {
     if (!EnsureFont(font))
         return;

--- a/source/platform/renderers/SFML2/SFML2.cpp
+++ b/source/platform/renderers/SFML2/SFML2.cpp
@@ -23,6 +23,11 @@
 #endif
 
 #include <cmath>
+#if defined(__unix__) || \\
+     defined(__linux__) || defined(__gnu__linux__) || \
+    (defined (__APPLE__) && defined(__MACH__))
+#include <unistd.h>
+#endif
 
 using namespace Gwk;
 

--- a/source/samples/SFML2/SFML2Sample.cpp
+++ b/source/samples/SFML2/SFML2Sample.cpp
@@ -21,10 +21,9 @@ int main()
     sf::RenderWindow app(sf::VideoMode(1004, 650, 32), "Gwork SFML2 Sample");
 
     Gwk::Platform::RelativeToExecutablePaths paths(GWORK_RESOURCE_DIR);
-    Gwk::Renderer::SFML2ResourceLoader loader(paths);
 
     // Create renderer
-    Gwk::Renderer::SFML2 renderer(loader, app);
+    Gwk::Renderer::SFML2 renderer(paths, app);
 
     // Create a Gwork skin
     Gwk::Skin::TexturedBase skin(&renderer);


### PR DESCRIPTION
>  - The renderer textures are looked up everytime a rect is drawn. This is too inefficient. How about storing a user data in the Texture.
>  - The utf8_to_wchart utility has unreachable code (returns).
>  - ...
>  - The software renderer texture colour sampling is broken.

This pull request aims to solve the issues you pointed out in #84. 
It also includes the update for the SFML2 renderer.