### PR TITLE
Fix typo in source/util/CMakeLists.txt

### DIFF
--- a/source/util/CMakeLists.txt
+++ b/source/util/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(
     ${GWK_SOURCE_DIR}/source/platform/include
     ${GWK_SOURCE_DIR}/source/gwork/include
     ${GWK_RENDER_INCLUDES}
-    ${CMAKE_SOURCE_DIR}/source/util/include
+    ${GWK_SOURCE_DIR}/source/util/include
     ${GWK_REFLECT_INCLUDE}
 )
 


### PR DESCRIPTION
GworkUtil tried to include `<MyProjectDir>/source/util` while the submodule is located at `<MyProjectDir>/Extern/GWork`. This was the result of using `CMAKE_SOURCE_DIR` instead of `GWK_SOURCE_DIR` in `include_directories`.