### PR TITLE
Fix opengl state when opengl is used for other rendering

### DIFF
--- a/source/platform/renderers/OpenGLCore/OpenGLCore.cpp
+++ b/source/platform/renderers/OpenGLCore/OpenGLCore.cpp
@@ -344,6 +344,11 @@ void OpenGLCore::Begin()
 {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glEnable(GL_BLEND);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_DEPTH_TEST);
+
+    //reset texture, we dont know what state someone else left it in
+    m_current_texture=0;
 }
 
 void OpenGLCore::End()


### PR DESCRIPTION
Force OpenGLCore renderer to re-load texture on draw as someone else could have changed it.
Also render expects not depth test or culling.